### PR TITLE
Remove version restriction on winston.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "winston": ""
   },
   "peerDependencies": {
-    "winston": ">=0.5.0 <2.0.0"
+    "winston": ">=0.5.0"
   },
   "main": "./lib/winston-mailgun.js",
   "engines": "",


### PR DESCRIPTION
Hi there, I see that this package requires winston `<2.0.0`, however the current version is `2.4.1`. I am using this package successfully with the latest version of winston, so I'm not sure why the requirement exists-- or perhaps it is outdated. Thanks.